### PR TITLE
update github release workflow

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -1,7 +1,6 @@
 name: version, tag and github release
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
 

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -1,6 +1,7 @@
 name: version, tag and github release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 
@@ -46,11 +47,11 @@ jobs:
             git push -u origin ${{ github.ref_name }}
           fi
       - name: Create Github Release
-        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         with:
           name: ${{ steps.version-check.outputs.tag }}
-          tag: ${{ steps.version-check.outputs.tag }}
-          commit: ${{ github.ref_name }}
-          token: ${{ secrets.GH_TOKEN }}
-          skipIfReleaseExists: true
+          tag_name: ${{ steps.version-check.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          make_latest: true
+          generate_release_notes: true


### PR DESCRIPTION
Uses the same workflow as stacks-core, this action worked in a fork using the same token that is available here. 

https://github.com/wileyj/send-many-stx-cli/releases
https://github.com/wileyj/send-many-stx-cli/actions/runs/13249457135/job/36983706438


https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs

