### PR TITLE
use PAT to enable triggering secondary workflow on release

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -46,11 +46,11 @@ jobs:
             git push -u origin ${{ github.ref_name }}
           fi
       - name: Create Github Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         with:
           name: ${{ steps.version-check.outputs.tag }}
-          tag_name: ${{ steps.version-check.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          make_latest: true
-          generate_release_notes: true
+          tag: ${{ steps.version-check.outputs.tag }}
+          commit: ${{ github.ref_name }}
+          token: ${{ secrets.PAT_TOKEN }}
+          skipIfReleaseExists: true


### PR DESCRIPTION
reverted to previous gh action release step and uses a PAT to create the release (this is what prevented the on:release trigger to not run. apparently it's protection against an endless loop). 

this fix should resolve all issues. incidentally, a scoped PAT fails here with the same error as before (unsure as to why). 